### PR TITLE
fix: removing redirection from module

### DIFF
--- a/admin/model/extension/module/d_twig_manager.php
+++ b/admin/model/extension/module/d_twig_manager.php
@@ -112,9 +112,6 @@ class ModelExtensionModuleDTwigManager extends Model {
             $this->installDatabase();
 
             $this->model_extension_d_opencart_patch_modification->refreshCache();
-
-            $this->load->model('extension/d_opencart_patch/url');
-            $this->response->redirect($this->model_extension_d_opencart_patch_url->link($this->request->get['route']));
         }
 
         return true;


### PR DESCRIPTION
I believe models can't do redirections, they have to be handled in controllers. I'm using your models as dependencies and the redirection was breaking my flow. 